### PR TITLE
Fix treating zero-length message as an EOF error.

### DIFF
--- a/any/002_configure.ac.patch
+++ b/any/002_configure.ac.patch
@@ -1,7 +1,7 @@
 diff -u a/configure.ac b/configure.ac
 --- a/configure.ac	2015-06-30 21:35:31.000000000 -0500
 +++ b/configure.ac	2017-01-10 10:14:30.085583817 -0600
-@@ -566,6 +566,40 @@
+@@ -566,6 +566,41 @@
  	AC_DEFINE([PTY_ZEROREAD], [1], [read(1) can return 0 for a non-closed fd])
  	AC_DEFINE([PLATFORM_SYS_DIR_UID], 2, [System dirs owned by bin (uid 2)])
  	;;
@@ -38,6 +38,7 @@ diff -u a/configure.ac b/configure.ac
 +    else
 +        AC_MSG_RESULT([$blibflags])
 +    fi
++    AC_DEFINE([PTY_ZEROREAD], [1], [read(1) can return 0 for a non-closed fd])
 +    ;;
  *-*-android*)
  	AC_DEFINE([DISABLE_UTMP], [1], [Define if you don't want to use utmp])


### PR DESCRIPTION
Verified by "npm test" command. 